### PR TITLE
Fix issue 11 - generated doEquals method only considers properties also selected for hashCode

### DIFF
--- a/pojomatic/src/main/java/org/pojomatic/internal/PojomatorByteCodeGenerator.java
+++ b/pojomatic/src/main/java/org/pojomatic/internal/PojomatorByteCodeGenerator.java
@@ -266,7 +266,7 @@ class PojomatorByteCodeGenerator {
     mv.visitFrame(F_FULL, 3, localVars, 0, NO_STACK);
 
     // Compare properties
-    for(PropertyElement propertyElement: classProperties.getHashCodeProperties()) {
+    for(PropertyElement propertyElement: classProperties.getEqualsProperties()) {
       visitLineNumber(14, propertyElement);
       visitAccessorAndConvert(varPojo1, propertyElement);
       visitLineNumber(15, propertyElement);


### PR DESCRIPTION
I'm rather surprised that this has gone undetected for four years; it would seem
that, while perfectly legal, it is rather rare for people to use a property
for equals but not hashCode.